### PR TITLE
Bullet heightmap js

### DIFF
--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -862,7 +862,8 @@ std::unique_ptr<btCollisionShape> createBulletEllipsoidMesh(
     triMesh->addTriangle(vertices[0], vertices[1], vertices[2]);
   }
 
-  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
+  std::unique_ptr<btGImpactMeshShape> gimpactMeshShape
+      = common::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
 
   return gimpactMeshShape;
@@ -891,7 +892,8 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpScene(
     }
   }
 
-  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
+  std::unique_ptr<btGImpactMeshShape> gimpactMeshShape
+      = common::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
   gimpactMeshShape->setUserPointer(triMesh);
 
@@ -899,7 +901,8 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpScene(
 }
 
 //==============================================================================
-std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpMesh(const aiMesh* mesh)
+std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpMesh(
+    const aiMesh* mesh)
 {
   auto triMesh = new btTriangleMesh();
 
@@ -914,7 +917,8 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpMesh(const
     triMesh->addTriangle(vertices[0], vertices[1], vertices[2]);
   }
 
-  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
+  std::unique_ptr<btGImpactMeshShape> gimpactMeshShape
+      = common::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
 
   return gimpactMeshShape;

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -862,11 +862,10 @@ std::unique_ptr<btCollisionShape> createBulletEllipsoidMesh(
     triMesh->addTriangle(vertices[0], vertices[1], vertices[2]);
   }
 
-  std::unique_ptr<btGImpactMeshShape> gimpactMeshShape
-      = common::make_unique<btGImpactMeshShape>(triMesh);
+  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
 
-  return gimpactMeshShape;
+  return std::move(gimpactMeshShape);
 }
 
 //==============================================================================
@@ -892,12 +891,11 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpScene(
     }
   }
 
-  std::unique_ptr<btGImpactMeshShape> gimpactMeshShape
-      = common::make_unique<btGImpactMeshShape>(triMesh);
+  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
   gimpactMeshShape->setUserPointer(triMesh);
 
-  return gimpactMeshShape;
+  return std::move(gimpactMeshShape);
 }
 
 //==============================================================================
@@ -917,11 +915,10 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpMesh(
     triMesh->addTriangle(vertices[0], vertices[1], vertices[2]);
   }
 
-  std::unique_ptr<btGImpactMeshShape> gimpactMeshShape
-      = common::make_unique<btGImpactMeshShape>(triMesh);
+  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
 
-  return gimpactMeshShape;
+  return std::move(gimpactMeshShape);
 }
 
 //==============================================================================
@@ -943,7 +940,7 @@ createBulletCollisionShapeFromHeightmap(
   if (std::is_same<HeightmapShape::HeightType, double>::value)
     scalarType = PHY_DOUBLE;
 
-  // TODO take this out when testing is finished  
+  // TODO take this out when testing is finished
   /*dtdbg << "Creating height shape, heights size " << heights.size()
         << " w = " << heightMap->getWidth() << ", h = "
         << heightMap->getDepth() << " min/max = "

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -927,6 +927,7 @@ createBulletCollisionShapeFromHeightmap(
     const dart::dynamics::HeightmapShape* heightMap)
 {
   using dart::dynamics::HeightmapShape;
+
   // get the heightmap parameters
   const Eigen::Vector3d& scale = heightMap->getScale();
   const HeightmapShape::HeightType minHeight = heightMap->getMinHeight();
@@ -978,7 +979,8 @@ createBulletCollisionShapeFromHeightmap(
   // bullet places the heightfield such that the origin is in the
   // middle of the AABB. We want however that the minimum height value
   // is on x/y plane.
-  btVector3 min, max;
+  btVector3 min;
+  btVector3 max;
   heightFieldShape->getAabb(btTransform::getIdentity(), min, max);
   dtdbg << "DART Bullet heightfield AABB: min = {"
         << min.x() << ", " << min.y() << ", " << min.z() << "}, max = {"

--- a/dart/collision/bullet/BulletCollisionDetector.hpp
+++ b/dart/collision/bullet/BulletCollisionDetector.hpp
@@ -41,6 +41,7 @@
 #include <btBulletCollisionCommon.h>
 #include "dart/collision/CollisionDetector.hpp"
 #include "dart/collision/bullet/BulletCollisionGroup.hpp"
+#include "dart/collision/bullet/BulletCollisionShape.hpp"
 
 namespace dart {
 namespace collision {
@@ -111,21 +112,19 @@ protected:
 
 private:
 
-  btCollisionShape* claimBulletCollisionShape(
-      const dynamics::ConstShapePtr& shape,
-      btTransform& relativeShapeTransform);
+  BulletCollisionShape* claimBulletCollisionShape(
+      const dynamics::ConstShapePtr& shape);
 
   void reclaimBulletCollisionShape(
       const dynamics::ConstShapePtr& shape);
 
-  btCollisionShape* createBulletCollisionShape(
-      const dynamics::ConstShapePtr& shape,
-      btTransform& relativeShapeTransform);
+  std::unique_ptr<BulletCollisionShape> createBulletCollisionShape(
+      const dynamics::ConstShapePtr& shape);
 
 private:
 
   std::map<dynamics::ConstShapePtr,
-           std::pair<btCollisionShape*, std::size_t>> mShapeMap;
+           std::pair<std::unique_ptr<BulletCollisionShape>, std::size_t>> mShapeMap;
 
   std::unique_ptr<BulletCollisionGroup> mGroupForFiltering;
 

--- a/dart/collision/bullet/BulletCollisionObject.cpp
+++ b/dart/collision/bullet/BulletCollisionObject.cpp
@@ -51,16 +51,16 @@ const btCollisionObject* BulletCollisionObject::getBulletCollisionObject() const
 }
 
 //==============================================================================
-BulletCollisionObject::BulletCollisionObject(
-    CollisionDetector* collisionDetector,
+BulletCollisionObject::BulletCollisionObject(CollisionDetector* collisionDetector,
     const dynamics::ShapeFrame* shapeFrame,
-    btCollisionShape* bulletCollisionShape,
-    const btTransform& relativeShapeTransform)
+    BulletCollisionShape* bulletCollisionShape)
   : CollisionObject(collisionDetector, shapeFrame),
     mBulletCollisionObject(new btCollisionObject()),
-    mRelativeShapeTransform(relativeShapeTransform)
+    mBulletCollisionShape(bulletCollisionShape)
 {
-  mBulletCollisionObject->setCollisionShape(bulletCollisionShape);
+  assert(bulletCollisionShape);
+
+  mBulletCollisionObject->setCollisionShape(mBulletCollisionShape->mCollisionShape.get());
   mBulletCollisionObject->setUserPointer(this);
 }
 
@@ -69,7 +69,10 @@ void BulletCollisionObject::updateEngineData()
 {
   btTransform worldTransform =
     convertTransform(mShapeFrame->getWorldTransform());
-  worldTransform *= mRelativeShapeTransform;
+
+  if (mBulletCollisionShape->mRelativeTransform)
+    worldTransform *= (*mBulletCollisionShape->mRelativeTransform);
+
   mBulletCollisionObject->setWorldTransform(worldTransform);
 }
 

--- a/dart/collision/bullet/BulletCollisionShape.cpp
+++ b/dart/collision/bullet/BulletCollisionShape.cpp
@@ -30,50 +30,28 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_BULLET_BULLETCOLLISIONOBJECT_HPP_
-#define DART_COLLISION_BULLET_BULLETCOLLISIONOBJECT_HPP_
-
-// Must be included before any Bullet headers.
-#include "dart/config.hpp"
-
-#include <btBulletCollisionCommon.h>
-
-#include "dart/collision/CollisionObject.hpp"
 #include "dart/collision/bullet/BulletCollisionShape.hpp"
 
 namespace dart {
 namespace collision {
 
-class CollisionObject;
-
-class BulletCollisionObject : public CollisionObject
+//==============================================================================
+BulletCollisionShape::BulletCollisionShape(
+    std::unique_ptr<btCollisionShape> collisionShape,
+    const btTransform& relativeTransform)
+  : mCollisionShape(std::move(collisionShape)),
+    mRelativeTransform(new btTransform(relativeTransform))
 {
-public:
-  friend class BulletCollisionDetector;
+  // Do nothing
+}
 
-  /// Return Bullet collision object
-  btCollisionObject* getBulletCollisionObject();
+//==============================================================================
+BulletCollisionShape::BulletCollisionShape(
+    std::unique_ptr<btCollisionShape> collisionShape)
+  : mCollisionShape(std::move(collisionShape)), mRelativeTransform(nullptr)
+{
+  // Do nothing
+}
 
-  /// Return Bullet collision object
-  const btCollisionObject* getBulletCollisionObject() const;
-
-protected:
-  /// Constructor
-  BulletCollisionObject(CollisionDetector* collisionDetector,
-                        const dynamics::ShapeFrame* shapeFrame,
-                        BulletCollisionShape* bulletCollisionShape);
-
-  // Documentation inherited
-  void updateEngineData() override;
-
-protected:
-  /// Bullet collision object
-  std::unique_ptr<btCollisionObject> mBulletCollisionObject;
-
-  BulletCollisionShape* mBulletCollisionShape;
-};
-
-}  // namespace collision
-}  // namespace dart
-
-#endif  // DART_COLLISION_BULLET_BULLETCOLLISIONOBJECT_HPP_
+} // namespace collision
+} // namespace dart

--- a/dart/collision/bullet/BulletCollisionShape.hpp
+++ b/dart/collision/bullet/BulletCollisionShape.hpp
@@ -30,50 +30,36 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_BULLET_BULLETCOLLISIONOBJECT_HPP_
-#define DART_COLLISION_BULLET_BULLETCOLLISIONOBJECT_HPP_
+#ifndef DART_COLLISION_BULLET_BULLETCOLLISIONSHAPE_HPP_
+#define DART_COLLISION_BULLET_BULLETCOLLISIONSHAPE_HPP_
+
+#include <memory>
 
 // Must be included before any Bullet headers.
 #include "dart/config.hpp"
 
 #include <btBulletCollisionCommon.h>
 
-#include "dart/collision/CollisionObject.hpp"
-#include "dart/collision/bullet/BulletCollisionShape.hpp"
-
 namespace dart {
 namespace collision {
 
-class CollisionObject;
-
-class BulletCollisionObject : public CollisionObject
+struct BulletCollisionShape
 {
-public:
-  friend class BulletCollisionDetector;
+  std::unique_ptr<btCollisionShape> mCollisionShape;
 
-  /// Return Bullet collision object
-  btCollisionObject* getBulletCollisionObject();
+  /// Relative transform of the shape to the collision object
+  /// which should be maintained at each pose update of the collision object.
+  /// Defaults to identity.
+  std::unique_ptr<btTransform> mRelativeTransform;
 
-  /// Return Bullet collision object
-  const btCollisionObject* getBulletCollisionObject() const;
+  BulletCollisionShape(
+      std::unique_ptr<btCollisionShape> collisionShape,
+      const btTransform& relativeTransform);
 
-protected:
-  /// Constructor
-  BulletCollisionObject(CollisionDetector* collisionDetector,
-                        const dynamics::ShapeFrame* shapeFrame,
-                        BulletCollisionShape* bulletCollisionShape);
-
-  // Documentation inherited
-  void updateEngineData() override;
-
-protected:
-  /// Bullet collision object
-  std::unique_ptr<btCollisionObject> mBulletCollisionObject;
-
-  BulletCollisionShape* mBulletCollisionShape;
+  BulletCollisionShape(std::unique_ptr<btCollisionShape> collisionShape);
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_BULLET_BULLETCOLLISIONOBJECT_HPP_
+#endif // DART_COLLISION_BULLET_BULLETCOLLISIONSHAPE_HPP_

--- a/dart/collision/bullet/CMakeLists.txt
+++ b/dart/collision/bullet/CMakeLists.txt
@@ -88,3 +88,8 @@ install(
   DESTINATION include/dart/collision/bullet
   COMPONENT headers
 )
+
+dart_format_add(
+  BulletCollisionShape.hpp
+  BulletCollisionShape.cpp
+)

--- a/dart/collision/ode/CMakeLists.txt
+++ b/dart/collision/ode/CMakeLists.txt
@@ -48,3 +48,8 @@ install(
   DESTINATION include/dart/collision/ode
   COMPONENT headers
 )
+
+dart_format_add(
+  detail/OdeHeightmap.hpp
+  detail/OdeHeightmap.cpp
+)

--- a/dart/collision/ode/CMakeLists.txt
+++ b/dart/collision/ode/CMakeLists.txt
@@ -51,5 +51,5 @@ install(
 
 dart_format_add(
   detail/OdeHeightmap.hpp
-  detail/OdeHeightmap.cpp
+  detail/OdeHeightmap-impl.hpp
 )

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -158,7 +158,8 @@ detail::OdeGeom* createOdeGeom(
   using dynamics::PlaneShape;
   using dynamics::MeshShape;
   using dynamics::SoftMeshShape;
-  using dynamics::HeightmapShape;
+  using dynamics::HeightmapShapef;
+  using dynamics::HeightmapShaped;
 
   detail::OdeGeom* geom = nullptr;
   const auto shape = shapeFrame->getShape().get();
@@ -209,10 +210,15 @@ detail::OdeGeom* createOdeGeom(
 
     geom = new detail::OdeMesh(collObj, aiScene, scale);
   }
-  else if (shape->is<HeightmapShape>())
+  else if (shape->is<HeightmapShapef>())
   {
-    auto heightMap= static_cast<const HeightmapShape*>(shape);
-    geom = new detail::OdeHeightmap(collObj, heightMap);
+    auto heightMap = static_cast<const HeightmapShapef*>(shape);
+    geom = new detail::OdeHeightmapf(collObj, heightMap);
+  }
+  else if (shape->is<HeightmapShaped>())
+  {
+    auto heightMap = static_cast<const HeightmapShaped*>(shape);
+    geom = new detail::OdeHeightmapd(collObj, heightMap);
   }
   else
   {

--- a/dart/collision/ode/detail/OdeHeightmap-impl.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap-impl.hpp
@@ -43,14 +43,14 @@ namespace detail {
 
 //==============================================================================
 // creates the ODE height field. Only enabled if the height data type is float.
-template <class HeightType>
+template <class S>
 void setOdeHeightfieldDetails(
     const dHeightfieldDataID odeHeightfieldId,
-    const HeightType* heights,
+    const S* heights,
     const std::size_t& width,
     const std::size_t& height,
     const Eigen::Vector3d& scale,
-    typename std::enable_if<std::is_same<float, HeightType>::value>::type* = 0)
+    typename std::enable_if<std::is_same<float, S>::value>::type* = 0)
 {
   assert(width >= 2);
   assert(height >= 2);
@@ -76,14 +76,14 @@ void setOdeHeightfieldDetails(
 
 //==============================================================================
 // creates the ODE height field. Only enabled if the height data type is double.
-template <class HeightType>
+template <class S>
 void setOdeHeightfieldDetails(
     const dHeightfieldDataID odeHeightfieldId,
-    const HeightType* heights,
+    const S* heights,
     const std::size_t& width,
     const std::size_t& height,
     const Eigen::Vector3d& scale,
-    typename std::enable_if<std::is_same<double, HeightType>::value>::type* = 0)
+    typename std::enable_if<std::is_same<double, S>::value>::type* = 0)
 {
   assert(width >= 2);
   assert(height >= 2);
@@ -109,25 +109,20 @@ void setOdeHeightfieldDetails(
 }
 
 //==============================================================================
-OdeHeightmap::OdeHeightmap(
+template <typename S>
+OdeHeightmap<S>::OdeHeightmap(
     const OdeCollisionObject* parent,
-    const dynamics::HeightmapShape* heightMap)
+    const dynamics::HeightmapShape<S>* heightMap)
   : OdeGeom(parent)
 {
-  using dynamics::HeightmapShape;
   assert(heightMap);
 
   // get the heightmap parameters
   const Eigen::Vector3d& scale = heightMap->getScale();
-  const HeightmapShape::HeightField& heights = heightMap->getHeightField();
+  const auto& heights = heightMap->getHeightField();
 
   // Create the ODE heightfield
   mOdeHeightfieldId = dGeomHeightfieldDataCreate();
-
-  static_assert(
-      std::is_same<HeightmapShape::HeightType, float>::value
-          || std::is_same<HeightmapShape::HeightType, double>::value,
-      "Height field needs to be double or float");
 
   // specify height field details
   setOdeHeightfieldDetails(
@@ -164,7 +159,8 @@ OdeHeightmap::OdeHeightmap(
 }
 
 //==============================================================================
-OdeHeightmap::~OdeHeightmap()
+template <typename S>
+OdeHeightmap<S>::~OdeHeightmap()
 {
   dGeomHeightfieldDataDestroy(mOdeHeightfieldId);
   dGeomDestroy(mGeomId);

--- a/dart/collision/ode/detail/OdeHeightmap.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap.hpp
@@ -42,23 +42,28 @@ namespace dart {
 namespace collision {
 namespace detail {
 
+template <typename S>
 class OdeHeightmap : public OdeGeom
 {
 public:
   /// Constructor
   OdeHeightmap(
-      const OdeCollisionObject* parent,
-      const dart::dynamics::HeightmapShape* hs);
+      const OdeCollisionObject* parent, const dynamics::HeightmapShape<S>* hs);
 
   /// Destructor
-  virtual ~OdeHeightmap();
+  ~OdeHeightmap() override;
 
 private:
   dHeightfieldDataID mOdeHeightfieldId;
 };
 
+using OdeHeightmapf = OdeHeightmap<float>;
+using OdeHeightmapd = OdeHeightmap<double>;
+
 } // namespace detail
 } // namespace collision
 } // namespace dart
+
+#include "dart/collision/ode/detail/OdeHeightmap-impl.hpp"
 
 #endif // DART_COLLISION_ODE_DETAIL_ODEHEIGHTMAP_HPP_

--- a/dart/collision/ode/detail/OdeHeightmap.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap.hpp
@@ -46,17 +46,19 @@ class OdeHeightmap : public OdeGeom
 {
 public:
   /// Constructor
-  OdeHeightmap(const OdeCollisionObject* parent,
-               const dart::dynamics::HeightmapShape* hs);
+  OdeHeightmap(
+      const OdeCollisionObject* parent,
+      const dart::dynamics::HeightmapShape* hs);
 
   /// Destructor
   virtual ~OdeHeightmap();
+
 private:
-  dHeightfieldDataID odeHeightfieldID;
+  dHeightfieldDataID mOdeHeightfieldId;
 };
 
 } // namespace detail
 } // namespace collision
 } // namespace dart
 
-#endif  // DART_COLLISION_ODE_DETAIL_ODEHEIGHTMAP_HPP_
+#endif // DART_COLLISION_ODE_DETAIL_ODEHEIGHTMAP_HPP_

--- a/dart/common/detail/LockableReference-impl.hpp
+++ b/dart/common/detail/LockableReference-impl.hpp
@@ -42,7 +42,8 @@ namespace common {
 template <typename Lockable>
 SingleLockableReference<Lockable>::SingleLockableReference(
     std::weak_ptr<const void> lockableHolder, Lockable& lockable) noexcept
-  : mLockableHolder(std::move(lockableHolder)), mLockable(lockable)
+    : mLockableHolder(std::move(lockableHolder)),
+      mLockable(lockable)
 {
   // Do nothing
 }

--- a/dart/dynamics/CMakeLists.txt
+++ b/dart/dynamics/CMakeLists.txt
@@ -42,8 +42,8 @@ dart_format_add(
 
 dart_format_add(
   HeightmapShape.hpp
-  HeightmapShape.cpp
   VoxelGridShape.hpp
   VoxelGridShape.cpp
   SmartPointer.hpp
+  detail/HeightmapShape-impl.hpp
 )

--- a/dart/dynamics/CMakeLists.txt
+++ b/dart/dynamics/CMakeLists.txt
@@ -41,6 +41,8 @@ dart_format_add(
 )
 
 dart_format_add(
+  HeightmapShape.hpp
+  HeightmapShape.cpp
   VoxelGridShape.hpp
   VoxelGridShape.cpp
   SmartPointer.hpp

--- a/dart/dynamics/HeightmapShape.cpp
+++ b/dart/dynamics/HeightmapShape.cpp
@@ -30,21 +30,21 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cmath>
 #include "dart/dynamics/HeightmapShape.hpp"
-#include "dart/dynamics/BoxShape.hpp"
-#include "dart/common/Console.hpp"
-#include <limits>
+
 #include <algorithm>
+#include <cmath>
+#include <limits>
+#include "dart/common/Console.hpp"
+#include "dart/dynamics/BoxShape.hpp"
 
 namespace dart {
 namespace dynamics {
 
 //==============================================================================
-HeightmapShape::HeightmapShape()
-  : Shape(HEIGHTMAP),
-    mScale(1, 1, 1)
+HeightmapShape::HeightmapShape() : Shape(HEIGHTMAP), mScale(1, 1, 1)
 {
+  // Do nothing
 }
 
 //==============================================================================
@@ -82,16 +82,18 @@ const Eigen::Vector3d& HeightmapShape::getScale() const
 {
   return mScale;
 }
- 
+
 //==============================================================================
-void HeightmapShape::setHeightField(const size_t& width, const size_t& depth,
-                                    const std::vector<HeightType>& heights)
+void HeightmapShape::setHeightField(
+    const std::size_t& width,
+    const std::size_t& depth,
+    const std::vector<HeightType>& heights)
 {
-  assert(heights.size() == width*depth);
-  if ((width*depth) != heights.size())
+  assert(heights.size() == width * depth);
+  if ((width * depth) != heights.size())
   {
-    dterr << "Size of height field needs to be width*depth="
-          << width*depth << std::endl;
+    dterr << "Size of height field needs to be width*depth=" << width * depth
+          << std::endl;
     return;
   }
   if (heights.empty())
@@ -104,7 +106,7 @@ void HeightmapShape::setHeightField(const size_t& width, const size_t& depth,
   {
     for (size_t c = 0; c < width; ++c)
     {
-      mHeights(r, c) = heights[r*width + c];
+      mHeights(r, c) = heights[r * width + c];
     }
   }
 
@@ -113,23 +115,23 @@ void HeightmapShape::setHeightField(const size_t& width, const size_t& depth,
   mMaxHeight = -std::numeric_limits<HeightType>::max();
   for (auto it = heights.begin(); it != heights.end(); ++it)
   {
-    if (*it < mMinHeight) mMinHeight = *it;
-    if (*it > mMaxHeight) mMaxHeight = *it;
+    if (*it < mMinHeight)
+      mMinHeight = *it;
+    if (*it > mMaxHeight)
+      mMaxHeight = *it;
   }
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
 }
 
 //==============================================================================
-const HeightmapShape::HeightField&
-  HeightmapShape::getHeightField() const
+const HeightmapShape::HeightField& HeightmapShape::getHeightField() const
 {
   return mHeights;
 }
 
 //==============================================================================
-HeightmapShape::HeightField&
-  HeightmapShape::getHeightFieldModifiable() const
+HeightmapShape::HeightField& HeightmapShape::getHeightFieldModifiable() const
 {
   return mHeights;
 }
@@ -153,13 +155,13 @@ HeightmapShape::HeightType HeightmapShape::getMinHeight() const
 }
 
 //==============================================================================
-size_t HeightmapShape::getWidth() const
+std::size_t HeightmapShape::getWidth() const
 {
   return mHeights.cols();
 }
 
 //==============================================================================
-size_t HeightmapShape::getDepth() const
+std::size_t HeightmapShape::getDepth() const
 {
   return mHeights.rows();
 }
@@ -173,22 +175,23 @@ Eigen::Matrix3d HeightmapShape::computeInertia(double mass) const
   }
   return BoxShape::computeInertia(getBoundingBox().computeFullExtents(), mass);
 }
-  
+
 //==============================================================================
-void HeightmapShape::computeBoundingBox(Eigen::Vector3d& min,
-                                        Eigen::Vector3d& max) const
+void HeightmapShape::computeBoundingBox(
+    Eigen::Vector3d& min, Eigen::Vector3d& max) const
 {
   const double dimX = getWidth() * mScale.x();
   const double dimY = getDepth() * mScale.y();
   const double dimZ = (mMaxHeight - mMinHeight) * mScale.z();
-  min = Eigen::Vector3d(-dimX*0.5, -dimY*0.5, mMinHeight*mScale.z());
+  min = Eigen::Vector3d(-dimX * 0.5, -dimY * 0.5, mMinHeight * mScale.z());
   max = min + Eigen::Vector3d(dimX, dimY, dimZ);
 }
 
 //==============================================================================
 void HeightmapShape::updateBoundingBox() const
 {
-  Eigen::Vector3d min, max;
+  Eigen::Vector3d min;
+  Eigen::Vector3d max;
   computeBoundingBox(min, max);
   mBoundingBox.setMin(min);
   mBoundingBox.setMax(max);
@@ -204,5 +207,5 @@ void HeightmapShape::updateVolume() const
   mIsVolumeDirty = false;
 }
 
-}  // namespace dynamics
-}  // namespace dart
+} // namespace dynamics
+} // namespace dart

--- a/dart/dynamics/HeightmapShape.hpp
+++ b/dart/dynamics/HeightmapShape.hpp
@@ -49,7 +49,8 @@ public:
   /// short and char can be added at a later point.
   using HeightType = float;
 
-  using HeightField = Eigen::Matrix<HeightType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  using HeightField = Eigen::
+      Matrix<HeightType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
   /// \brief Constructor.
   explicit HeightmapShape();
@@ -85,38 +86,40 @@ public:
   /// a (mutable) copy of the height values passed in \e heights will be kept
   /// in this class. The copied data can be modified via
   /// getHeightFieldModifiable() and with flipY().
-  /// 
+  ///
   /// \param[in] width width of the field (x axis)
   /// \param[in] depth depth of the field (-y axis)
   /// \param[in] heights the height data of size \e width * \e depth.
-  //    The heights are interpreted as z values, while \e width goes in x 
+  //    The heights are interpreted as z values, while \e width goes in x
   //    direction and \e depth in -y (it goes to -y because traditionally
   //    images are read from top row to bottom row).
   //    In the geometry which is to be generated from this shape, the min/max
-  //    height value is also the min/max z value (so if the minimum height 
+  //    height value is also the min/max z value (so if the minimum height
   //    value is -100, the lowest terrain point will be -100, times the z
   //    scale to be applied).
-  void setHeightField(const size_t& width, const size_t& depth,
-                      const std::vector<HeightType>& heights);
+  void setHeightField(
+      const std::size_t& width,
+      const std::size_t& depth,
+      const std::vector<HeightType>& heights);
 
   /// \brief Get the height field.
   const HeightField& getHeightField() const;
-  
+
   /// \brief Gets the modified height field. See also setHeightField().
   HeightField& getHeightFieldModifiable() const;
 
   /// \brief Flips the y values in the height field.
-  void flipY() const; 
+  void flipY() const;
 
   /// \brief Get the width dimension of the height field
-  size_t getWidth() const;
-  
+  std::size_t getWidth() const;
+
   /// \brief Get the height dimension of the height field
-  size_t getDepth() const;
+  std::size_t getDepth() const;
 
   /// \brief Get the minimum height set by setHeightField()
   HeightType getMinHeight() const;
-  
+
   /// \brief Get the maximum height set by setHeightField()
   HeightType getMaxHeight() const;
 
@@ -129,12 +132,11 @@ protected:
   /// the volume of the bounding box. Subclasses may opt to provide a more
   /// accurate computation of the volume.
   virtual void updateVolume() const override;
- 
+
   /// \brief Computes the bounding box of the height field.
-  /// \param[out] min mininum of box
-  /// \param[out] max maxinum of box
-  void computeBoundingBox(Eigen::Vector3d& min,
-                          Eigen::Vector3d& max) const;
+  /// \param[out] min Mininum of box
+  /// \param[out] max Maxinum of box
+  void computeBoundingBox(Eigen::Vector3d& min, Eigen::Vector3d& max) const;
 
 private:
   /// \brief scale of the heightmap
@@ -148,7 +150,7 @@ private:
   HeightType mMinHeight, mMaxHeight;
 };
 
-}  // namespace dynamics
-}  // namespace dart
+} // namespace dynamics
+} // namespace dart
 
-#endif  // DART_DYNAMICS_HEIGHTMAPSHAPE_HPP_
+#endif // DART_DYNAMICS_HEIGHTMAPSHAPE_HPP_

--- a/dart/dynamics/HeightmapShape.hpp
+++ b/dart/dynamics/HeightmapShape.hpp
@@ -47,9 +47,9 @@ public:
   /// \brief Data type used for height map. Could be made template.
   /// At this point, only double and float are supported.
   /// short and char can be added at a later point.
-  typedef float HeightType;
+  using HeightType = float;
 
-  typedef Eigen::Matrix<HeightType, Eigen::Dynamic, Eigen::Dynamic> HeightField;
+  using HeightField = Eigen::Matrix<HeightType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
   /// \brief Constructor.
   explicit HeightmapShape();

--- a/dart/dynamics/HeightmapShape.hpp
+++ b/dart/dynamics/HeightmapShape.hpp
@@ -38,25 +38,24 @@
 namespace dart {
 namespace dynamics {
 
-/**
- * \brief Shape for a height map.
- */
+/// Shape for a height map.
+///
+/// \tparam S_ Data type used for height map. At this point, only double and
+/// float are supported. Short and char can be added at a later point.
+template <typename S_>
 class HeightmapShape : public Shape
 {
 public:
-  /// \brief Data type used for height map. Could be made template.
-  /// At this point, only double and float are supported.
-  /// short and char can be added at a later point.
-  using HeightType = float;
+  using S = S_;
 
-  using HeightField = Eigen::
-      Matrix<HeightType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  using HeightField
+      = Eigen::Matrix<S, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
-  /// \brief Constructor.
-  explicit HeightmapShape();
+  /// Constructor.
+  HeightmapShape();
 
-  /// \brief Destructor.
-  virtual ~HeightmapShape();
+  /// Destructor.
+  ~HeightmapShape() override = default;
 
   // Documentation inherited.
   const std::string& getType() const override;
@@ -64,19 +63,22 @@ public:
   /// Returns shape type for this class
   static const std::string& getStaticType();
 
-  // Documentation inherited.
-  // This base class computes the intertia based on the bounding box.
-  // Subclasses may choose to provide a more accurate computation of the inertia
-  virtual Eigen::Matrix3d computeInertia(double mass) const override;
+  /// \copydoc Shape::computeInertia()
+  ///
+  /// This base class computes the intertia based on the bounding box.
+  /// Subclasses may choose to provide a more accurate computation of the
+  /// inertia.
+  Eigen::Matrix3d computeInertia(double mass) const override;
 
-  /// \brief Set scale of this heightmap.
-  /// \param[in] scale scale of the height map.
+  /// Sets scale of this heightmap.
+  /// \param[in] scale Scale of the height map.
   void setScale(const Eigen::Vector3d& scale);
 
-  /// \brief Get scale of this heightmap.
+  /// Returns scale of this heightmap.
   const Eigen::Vector3d& getScale() const;
 
-  /// \brief Set the height field.
+  /// Sets the height field.
+  ///
   /// The data in \e heights will be copied locally.
   /// It would be nice to have the option to use the values in
   /// \e heights directly instead of copying them locally to a vector in this
@@ -87,70 +89,80 @@ public:
   /// in this class. The copied data can be modified via
   /// getHeightFieldModifiable() and with flipY().
   ///
-  /// \param[in] width width of the field (x axis)
-  /// \param[in] depth depth of the field (-y axis)
-  /// \param[in] heights the height data of size \e width * \e depth.
-  //    The heights are interpreted as z values, while \e width goes in x
-  //    direction and \e depth in -y (it goes to -y because traditionally
-  //    images are read from top row to bottom row).
-  //    In the geometry which is to be generated from this shape, the min/max
-  //    height value is also the min/max z value (so if the minimum height
-  //    value is -100, the lowest terrain point will be -100, times the z
-  //    scale to be applied).
+  /// \param[in] width Width of the field (x axis)
+  /// \param[in] depth Depth of the field (-y axis)
+  /// \param[in] heights The height data of size \e width * \e depth.
+  /// The heights are interpreted as z values, while \e width goes in x
+  /// direction and \e depth in -y (it goes to -y because traditionally
+  /// images are read from top row to bottom row).
+  /// In the geometry which is to be generated from this shape, the min/max
+  /// height value is also the min/max z value (so if the minimum height
+  /// value is -100, the lowest terrain point will be -100, times the z
+  /// scale to be applied).
   void setHeightField(
       const std::size_t& width,
       const std::size_t& depth,
-      const std::vector<HeightType>& heights);
+      const std::vector<S>& heights);
 
-  /// \brief Get the height field.
+  /// Returns the height field.
   const HeightField& getHeightField() const;
 
-  /// \brief Gets the modified height field. See also setHeightField().
+  /// Returns the modified height field. See also setHeightField().
   HeightField& getHeightFieldModifiable() const;
 
-  /// \brief Flips the y values in the height field.
+  /// Flips the y values in the height field.
   void flipY() const;
 
-  /// \brief Get the width dimension of the height field
+  /// Returns the width dimension of the height field
   std::size_t getWidth() const;
 
-  /// \brief Get the height dimension of the height field
+  /// Returns the height dimension of the height field
   std::size_t getDepth() const;
 
-  /// \brief Get the minimum height set by setHeightField()
-  HeightType getMinHeight() const;
+  /// Returns the minimum height set by setHeightField()
+  S getMinHeight() const;
 
-  /// \brief Get the maximum height set by setHeightField()
-  HeightType getMaxHeight() const;
+  /// Returns the maximum height set by setHeightField()
+  S getMaxHeight() const;
 
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;
 
-  /// Documentation inherited.
+  /// \copydoc Shape::updateVolume()
+  ///
   /// This base class provides a simple implementation which returns
   /// the volume of the bounding box. Subclasses may opt to provide a more
   /// accurate computation of the volume.
-  virtual void updateVolume() const override;
+  void updateVolume() const override;
 
-  /// \brief Computes the bounding box of the height field.
+  /// Computes the bounding box of the height field.
   /// \param[out] min Mininum of box
   /// \param[out] max Maxinum of box
   void computeBoundingBox(Eigen::Vector3d& min, Eigen::Vector3d& max) const;
 
 private:
-  /// \brief scale of the heightmap
+  /// Scale of the heightmap
   Eigen::Vector3d mScale;
 
-  /// \brief height field
+  /// Height field
   mutable HeightField mHeights;
 
-  /// \brief minimum and maximum heights.
+  /// Minimum heights.
   /// Is computed each time the height field is set with setHeightField().
-  HeightType mMinHeight, mMaxHeight;
+  S mMinHeight;
+
+  /// Maximum heights.
+  /// Is computed each time the height field is set with setHeightField().
+  S mMaxHeight;
 };
+
+using HeightmapShapef = HeightmapShape<float>;
+using HeightmapShaped = HeightmapShape<double>;
 
 } // namespace dynamics
 } // namespace dart
+
+#include "dart/dynamics/detail/HeightmapShape-impl.hpp"
 
 #endif // DART_DYNAMICS_HEIGHTMAPSHAPE_HPP_

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -112,7 +112,7 @@ public:
   ///        such as BoxShape, EllipsoidShape, CylinderShape, and MeshShape.
   const math::BoundingBox& getBoundingBox() const;
 
-  /// \brief
+  /// Computes the inertia.
   virtual Eigen::Matrix3d computeInertia(double mass) const = 0;
 
   Eigen::Matrix3d computeInertiaFromDensity(double density) const;

--- a/dart/dynamics/detail/HeightmapShape-impl.hpp
+++ b/dart/dynamics/detail/HeightmapShape-impl.hpp
@@ -42,32 +42,33 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-HeightmapShape::HeightmapShape() : Shape(HEIGHTMAP), mScale(1, 1, 1)
+template <typename S>
+HeightmapShape<S>::HeightmapShape() : Shape(HEIGHTMAP), mScale(1, 1, 1)
 {
-  // Do nothing
+  static_assert(
+      std::is_same<S, float>::value || std::is_same<S, double>::value,
+      "Height field needs to be double or float");
 }
 
 //==============================================================================
-HeightmapShape::~HeightmapShape()
-{
-  // Do nothing
-}
-
-//==============================================================================
-const std::string& HeightmapShape::getType() const
+template <typename S>
+const std::string& HeightmapShape<S>::getType() const
 {
   return getStaticType();
 }
 
 //==============================================================================
-const std::string& HeightmapShape::getStaticType()
+template <typename S>
+const std::string& HeightmapShape<S>::getStaticType()
 {
-  static const std::string type("HeightmapShape");
+  static const std::string type
+      = "HeightmapShape (" + std::string(typeid(S).name()) + ")";
   return type;
 }
 
 //==============================================================================
-void HeightmapShape::setScale(const Eigen::Vector3d& scale)
+template <typename S>
+void HeightmapShape<S>::setScale(const Eigen::Vector3d& scale)
 {
   assert(scale[0] > 0.0);
   assert(scale[1] > 0.0);
@@ -78,16 +79,18 @@ void HeightmapShape::setScale(const Eigen::Vector3d& scale)
 }
 
 //==============================================================================
-const Eigen::Vector3d& HeightmapShape::getScale() const
+template <typename S>
+const Eigen::Vector3d& HeightmapShape<S>::getScale() const
 {
   return mScale;
 }
 
 //==============================================================================
-void HeightmapShape::setHeightField(
+template <typename S>
+void HeightmapShape<S>::setHeightField(
     const std::size_t& width,
     const std::size_t& depth,
-    const std::vector<HeightType>& heights)
+    const std::vector<S>& heights)
 {
   assert(heights.size() == width * depth);
   if ((width * depth) != heights.size())
@@ -111,8 +114,8 @@ void HeightmapShape::setHeightField(
   }
 
   // compute minimum and maximum height
-  mMinHeight = std::numeric_limits<HeightType>::max();
-  mMaxHeight = -std::numeric_limits<HeightType>::max();
+  mMinHeight = std::numeric_limits<S>::max();
+  mMaxHeight = -std::numeric_limits<S>::max();
   for (auto it = heights.begin(); it != heights.end(); ++it)
   {
     if (*it < mMinHeight)
@@ -125,49 +128,57 @@ void HeightmapShape::setHeightField(
 }
 
 //==============================================================================
-const HeightmapShape::HeightField& HeightmapShape::getHeightField() const
+template <typename S>
+auto HeightmapShape<S>::getHeightField() const -> const HeightField&
 {
   return mHeights;
 }
 
 //==============================================================================
-HeightmapShape::HeightField& HeightmapShape::getHeightFieldModifiable() const
+template <typename S>
+auto HeightmapShape<S>::getHeightFieldModifiable() const -> HeightField&
 {
   return mHeights;
 }
 
 //==============================================================================
-void HeightmapShape::flipY() const
+template <typename S>
+void HeightmapShape<S>::flipY() const
 {
   mHeights = mHeights.colwise().reverse().eval();
 }
 
 //==============================================================================
-HeightmapShape::HeightType HeightmapShape::getMaxHeight() const
+template <typename S>
+auto HeightmapShape<S>::getMaxHeight() const -> S
 {
   return mMaxHeight;
 }
 
 //==============================================================================
-HeightmapShape::HeightType HeightmapShape::getMinHeight() const
+template <typename S>
+auto HeightmapShape<S>::getMinHeight() const -> S
 {
   return mMinHeight;
 }
 
 //==============================================================================
-std::size_t HeightmapShape::getWidth() const
+template <typename S>
+std::size_t HeightmapShape<S>::getWidth() const
 {
   return mHeights.cols();
 }
 
 //==============================================================================
-std::size_t HeightmapShape::getDepth() const
+template <typename S>
+std::size_t HeightmapShape<S>::getDepth() const
 {
   return mHeights.rows();
 }
 
 //==============================================================================
-Eigen::Matrix3d HeightmapShape::computeInertia(double mass) const
+template <typename S>
+Eigen::Matrix3d HeightmapShape<S>::computeInertia(double mass) const
 {
   if (mIsBoundingBoxDirty)
   {
@@ -177,7 +188,8 @@ Eigen::Matrix3d HeightmapShape::computeInertia(double mass) const
 }
 
 //==============================================================================
-void HeightmapShape::computeBoundingBox(
+template <typename S>
+void HeightmapShape<S>::computeBoundingBox(
     Eigen::Vector3d& min, Eigen::Vector3d& max) const
 {
   const double dimX = getWidth() * mScale.x();
@@ -188,7 +200,8 @@ void HeightmapShape::computeBoundingBox(
 }
 
 //==============================================================================
-void HeightmapShape::updateBoundingBox() const
+template <typename S>
+void HeightmapShape<S>::updateBoundingBox() const
 {
   Eigen::Vector3d min;
   Eigen::Vector3d max;
@@ -199,7 +212,8 @@ void HeightmapShape::updateBoundingBox() const
 }
 
 //==============================================================================
-void HeightmapShape::updateVolume() const
+template <typename S>
+void HeightmapShape<S>::updateVolume() const
 {
   updateBoundingBox();
   const Eigen::Vector3d size = mBoundingBox.getMax() - mBoundingBox.getMin();

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
@@ -124,10 +124,10 @@ struct TranslationalJoint2DProperties : GenericJoint<math::R2Space>::Properties,
 };
 
 //==============================================================================
-using TranslationalJoint2DBase = common::EmbedPropertiesOnTopOf<
-    TranslationalJoint2D,
-    TranslationalJoint2DUniqueProperties,
-    GenericJoint<math::R2Space>>;
+using TranslationalJoint2DBase
+    = common::EmbedPropertiesOnTopOf<TranslationalJoint2D,
+                                     TranslationalJoint2DUniqueProperties,
+                                     GenericJoint<math::R2Space>>;
 
 } // namespace detail
 } // namespace dynamics

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -1148,8 +1148,8 @@ void testHeightmapBox(const std::shared_ptr<CollisionDetector>& cd,
   // ODE thickness is only used if there is not already a layer of this
   // thickness due to a minH > 0 (for ODE, extendsUntilGroundPlane is true)
   const float useOdeThck = (odeThck > 1e-06) ? std::max(odeThck-minH, 0.0f) : 0;
-  
-  // Create frames and shapes 
+
+  // Create frames and shapes
   ///////////////////////////////////////
 
   // frames and shapes
@@ -1170,13 +1170,13 @@ void testHeightmapBox(const std::shared_ptr<CollisionDetector>& cd,
 
   terrainFrame->setShape(terrainShape);
   boxFrame->setShape(boxShape);
-  
+
   // Test collisions
   ///////////////////////////////////////
 
   auto group = cd->createCollisionGroup(terrainFrame.get(), boxFrame.get());
   EXPECT_EQ(group->getNumShapeFrames(), 2u);
-  
+
   collision::CollisionOption option;
   option.enableContact = true;
 
@@ -1224,7 +1224,7 @@ void testHeightmapBox(const std::shared_ptr<CollisionDetector>& cd,
   // ODE doesn't do nicely when boxes are close to the border.
   // Shift the boxes along the slope or normal to slope by this length.
   // Technically we should compute this a bit more accurately than this.
-  // it basically has to ensure the box is inside the terrain bounds, so 
+  // it basically has to ensure the box is inside the terrain bounds, so
   // the slope plays a role for this factor. But since the box is small,
   // an estimate is used for now.
   const float boxShift = boxSize * 2;
@@ -1242,7 +1242,7 @@ void testHeightmapBox(const std::shared_ptr<CollisionDetector>& cd,
   boxFrame->setTranslation(cornerShift);
   EXPECT_FALSE(group->collide(option, &result));
   EXPECT_EQ(result.getNumContacts(), 0u);
-  
+
   // test collisions for box on z axis
   // /////////////////////////////////////
 


### PR DESCRIPTION
Summary of changes:
* Fixes test failures by storing both `btCollisionShape` and its relative transform in the bullet collision object manager (i.e., `mShapeMap`)
* Change creator functions to return `std::unique_ptr` instead of raw pointer to be explicit in ownership managemant
* Make `HeightMapShape` as template class so that it can actually support `float` and `double` scalar types
* Format new files using `clang-format-3.8`

Caveat:
* `testHeightmapBox` test is failing for Bullet + `double` for some reason